### PR TITLE
style(prettirerc): update .prettierrc to match the eslint endOfLine rule

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "semi": true,
   "singleQuote": false,
   "tabWidth": 4,
-  "trailingComma": "none"
+  "trailingComma": "none",
+  "endOfLine": "lf"
 }


### PR DESCRIPTION
add to `.prettierrc` file the `endOfLine` rule that declared in the
eslint config file so they match