### PR TITLE
chore(git): add `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+# Declare files that will always have LF line endings on checkout.
+* text=auto eol=lf


### PR DESCRIPTION
add `.gitattributes` to automatically checkout/clone in the right end line format