### PR TITLE
Add basic test for OnFleetService#deleteTask 

### DIFF
--- a/functions/services/onfleet/delete-task.test.js
+++ b/functions/services/onfleet/delete-task.test.js
@@ -1,0 +1,45 @@
+const { deleteTask } = require("./index");
+
+// Mock out the node-onfleet library
+jest.mock("@onfleet/node-onfleet");
+const Onfleet = require("@onfleet/node-onfleet");
+
+describe("OnFleetService#deleteTask", () => {
+    const fakeOnfleetKey = "fake-key";
+
+    const fakeApiResponse = { fake: "response" };
+    const fakeOnfleetClient = {
+        tasks: {
+            deleteOne: jest.fn().mockResolvedValue(fakeApiResponse)
+        }
+    };
+
+    beforeEach(() => {
+        process.env = {
+            ONFLEET_KEY: fakeOnfleetKey
+        };
+
+        // Mock the implementation of the constructor of Onfleet
+        Onfleet.mockImplementation(() => {
+            return fakeOnfleetClient;
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should trigger deleteOne on tasks using the id provided and return the response", async () => {
+        const taskId = 5;
+
+        const response = await deleteTask(taskId);
+        expect(response).toBe(fakeApiResponse);
+
+        // Ensure that the Onfleet client was constructed using
+        // the fake key from process.env.ONFLEET_KEY
+        expect(Onfleet.mock.calls[0][0]).toBe(fakeOnfleetKey);
+
+        // Check that the deleteOne used the taskId provided.
+        expect(fakeOnfleetClient.tasks.deleteOne.mock.calls[0][0]).toBe(taskId);
+    });
+});

--- a/functions/services/onfleet/index.js
+++ b/functions/services/onfleet/index.js
@@ -1,13 +1,11 @@
 const logger = require("../../../utils/logger/");
 const Onfleet = require("@onfleet/node-onfleet");
 
-const onfleet = new Onfleet(process.env.ONFLEET_KEY);
-
 const createTask = (
     address,
     person,
     notes,
-    taskCreator = onfleet.tasks.create
+    taskCreator = getOnfleetClient().tasks.create
 ) => {
     if (!address || !person || !notes) {
         throw new Error("Missing required args: address, person and/or notes.");
@@ -21,21 +19,21 @@ const createTask = (
 };
 
 const deleteTask = id => {
-    return onfleet.tasks.deleteOne(id);
+    return getOnfleetClient().tasks.deleteOne(id);
 };
 
 const getTask = id => {
-    return onfleet.tasks.get(id);
+    return getOnfleetClient().tasks.get(id);
 };
 
 const updateTask = (id, body) => {
-    return onfleet.tasks.update(id, body);
+    return getOnfleetClient().tasks.update(id, body);
 };
 
 const createTeam = async neighborhoodData => {
     const name = neighborhoodData.short_name.replace("/", "-");
     const neighborhoodID = neighborhoodData.id;
-    const response = await onfleet.teams.create({
+    const response = await getOnfleetClient().teams.create({
         name: neighborhoodID
     });
 
@@ -50,12 +48,16 @@ const createTeam = async neighborhoodData => {
 
 const createWorker = async (teamId, name, phone) => {
     logger.debug({ teamId, name, phone });
-    return onfleet.workers.create({
+    return getOnfleetClient().workers.create({
         name: name,
         phone: phone,
         teams: [teamId.toString()]
     });
 };
+
+function getOnfleetClient() {
+    return new Onfleet(process.env.ONFLEET_KEY);
+}
 
 module.exports = {
     createTask,


### PR DESCRIPTION
This PR does the following:

- Add a basic test for `OnFleetService#deleteTask` to ensure it just returns the correct response and calls the dependency functions correctly.
- Removed the requirement to have an env file defined by faking the `process.env`
- Modified `functions/services/onfleet/index.js` to use `getOnfleetClient()` function to accommodate the approach for mocking constructors. **Seemed like having the `onfleet` client defined on require made mocking challenging**